### PR TITLE
Handle errors when calculating hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ For more information about how to use duometer see [this tutorial](http://pmande
 
 The only prerequisite is a Java runtime.
 
-1. Download the current version of the tool [here](http://www.pawelmandera.com/download/duometer-0.1.2.zip).
+1. Download the current version of the tool [here](http://www.pawelmandera.com/download/duometer-0.1.3.zip).
 2. Extract the archive and go to `./bin`.
 3. Run `./duometer`  (on Linux and Mac) or `duometer.bat` (on Windows).
 
 ## Debian (Ubuntu)
 
-Download [a package](http://www.pawelmandera.com/download/duometer_0.1.2_all.deb)
+Download [a package](http://www.pawelmandera.com/download/duometer_0.1.3_all.deb)
 and run:
 
 ```bash
-sudo dpkg -i duometer_0.1.2_all.deb
+sudo dpkg -i duometer_0.1.3_all.deb
 ```
 
 `duometer` is now installed and should be available as a shell command.

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "duometer"
 
 organization := "com.pawelmandera"
 
-version := "0.1.2"
+version := "0.1.3"
 
 scalaVersion := "2.11.4"
 

--- a/src/main/scala/com/pawelmandera/hash/ElementHashes.scala
+++ b/src/main/scala/com/pawelmandera/hash/ElementHashes.scala
@@ -1,13 +1,15 @@
 package com.pawelmandera.hash
 
+import scala.util.Try
+
 /** A typeclass for things that can be mapped to a Set of Long hashes.*/
 trait ElementHashes[-A] {
-  def hashes(x: A): Set[Long]
+  def hashes(x: A): Try[Set[Long]]
 }
 
 object ElementHashes {
   implicit object ShingleElementHashes extends ElementHashes[List[String]] {
-    def hashes(x: List[String]): Set[Long] =
-      (x map { LongHash.stringHash(_) }).toSet
+    def hashes(x: List[String]): Try[Set[Long]] =
+      Try { (x map { LongHash.stringHash(_) }).toSet }
   }
 }

--- a/src/test/scala/com/pawelmandera/duplicates/MinHashDetectionSpec.scala
+++ b/src/test/scala/com/pawelmandera/duplicates/MinHashDetectionSpec.scala
@@ -1,5 +1,7 @@
 package com.pawelmandera.duplicates
 
+import scala.util.Try
+
 import org.specs2.mutable._
 
 import com.pawelmandera.hash.ElementHashes
@@ -10,7 +12,7 @@ class MinHashDetectionSpec extends Specification {
   def jaccard[A](s1: Set[A], s2: Set[A]) = (s1 & s2).size.toDouble/(s1 ++ s2).size
 
   implicit object SymbolSetElementHashes extends ElementHashes[Set[Symbol]] {
-    def hashes(x: Set[Symbol]) = {
+    def hashes(x: Set[Symbol]) = Try {
       val xs = x.toSeq map { _.toString }
       val hs = xs map { _.hashCode.toLong }
       hs.toSet

--- a/src/test/scala/com/pawelmandera/duplicates/MinHashFunctionsSpec.scala
+++ b/src/test/scala/com/pawelmandera/duplicates/MinHashFunctionsSpec.scala
@@ -27,7 +27,7 @@ class MinHashFunctionsSpec extends Specification {
       val text = "this is some text".split(" ").toList
       val hashFunc = mhf.hashFunctions(3, 1)
       val s = mhf.sketch(text, hashFunc)
-      s.length must_== 3
+      s.get.length must_== 3
     }
   }
 }

--- a/src/test/scala/com/pawelmandera/duplicates/SharedMemberCandidatesSpec.scala
+++ b/src/test/scala/com/pawelmandera/duplicates/SharedMemberCandidatesSpec.scala
@@ -1,5 +1,6 @@
 package com.pawelmandera.duplicates
 
+import scala.util.Try
 import org.specs2.mutable._
 
 import com.pawelmandera.hash.ElementHashes
@@ -8,7 +9,7 @@ class SharedMemberCandidatesSpec extends Specification {
   val smc = new SharedMemberCandidates {}
 
   implicit object SymbolSetElementHashes extends ElementHashes[Set[Symbol]] {
-    def hashes(x: Set[Symbol]) = {
+    def hashes(x: Set[Symbol]) = Try {
       val xs = x.toSeq map { _.toString }
       val hs = xs map { _.hashCode.toLong }
       hs.toSet

--- a/src/test/scala/com/pawelmandera/io/TextFileSpec.scala
+++ b/src/test/scala/com/pawelmandera/io/TextFileSpec.scala
@@ -1,5 +1,7 @@
 package com.pawelmandera.io
 
+import scala.util.Success
+
 import org.specs2.mutable._
 import org.specs2.mock._
 import org.specs2.specification.Scope
@@ -8,18 +10,18 @@ import org.specs2.specification.Scope
 class TextFileSpec extends Specification {
   trait TestData extends Scope {
     val mockedFile = new TextFile("test/path") with HasTextLines {
-      val lines = Vector(
+      val lines = Success(Vector(
         "This is a first line",
         "This is a second line",
         "This is a third line"
-      )
+      ))
     }
   }
 
   "A TextFile object " should {
     "return the text" in new TestData {
       val text = mockedFile.text
-      text must_== mockedFile.lines.mkString("\n")
+      text.get must_== mockedFile.lines.get.mkString("\n")
     }
   }
 }


### PR DESCRIPTION
This allows to handle errors when calculating hashes, which is
especially important when parsing files with Tika.

The errors are handled using Try, first in hashes method of the
ElementHashes typeclass. Files for which hashing failed are later
ignored in the pipeline.

Version incremented to 0.1.3.

Closes #3.
